### PR TITLE
fix(nx-web-ext): use react or angular import when needed

### DIFF
--- a/packages/nx-web-ext/src/generators/application/generator.ts
+++ b/packages/nx-web-ext/src/generators/application/generator.ts
@@ -7,8 +7,6 @@ import {
 } from '@nx/devkit';
 import * as path from 'path';
 import type { NxWebExtGeneratorSchema } from './schema';
-import { angularApp } from './sub-generators/angular';
-import { reactApp } from './sub-generators/react';
 
 export interface NormalizedSchema extends NxWebExtGeneratorSchema {
   /**
@@ -66,10 +64,10 @@ export default async function (tree: Tree, options: NxWebExtGeneratorSchema) {
 
   switch (normalizedOptions.framework) {
     case 'angular':
-      await angularApp(tree, normalizedOptions);
+      await import('./sub-generators/angular').then(({ angularApp }) => angularApp(tree, normalizedOptions));
       break;
     case 'react':
-      await reactApp(tree, normalizedOptions);
+      await import('./sub-generators/react').then(({ reactApp }) => reactApp(tree, normalizedOptions));
       break;
     default:
       throw new Error('This application target is not supported.');

--- a/packages/nx-web-ext/src/generators/application/generator.ts
+++ b/packages/nx-web-ext/src/generators/application/generator.ts
@@ -63,12 +63,16 @@ export default async function (tree: Tree, options: NxWebExtGeneratorSchema) {
   const normalizedOptions = normalizeOptions(options);
 
   switch (normalizedOptions.framework) {
-    case 'angular':
-      await import('./sub-generators/angular').then(({ angularApp }) => angularApp(tree, normalizedOptions));
+    case 'angular': {
+      const { angularApp } = await import('./sub-generators/angular');
+      await angularApp(tree, normalizedOptions);
       break;
-    case 'react':
-      await import('./sub-generators/react').then(({ reactApp }) => reactApp(tree, normalizedOptions));
+    }
+    case 'react': {
+      const { reactApp } = await import('./sub-generators/react');
+      await reactApp(tree, normalizedOptions);
       break;
+    }
     default:
       throw new Error('This application target is not supported.');
   }


### PR DESCRIPTION
There is an error if you only want to use "react" (for example) and you don't have angular dependencies, and the same the other way around

With this modification, the code will import only react or angular when you choose for one