### PR TITLE
Drop --yes from the nx release invocation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       # which nx release would use and which does not carry npm's OIDC flow.
       - name: Version and changelog
         shell: bash
-        run: pnpm exec nx release --yes --skip-publish
+        run: pnpm exec nx release --skip-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

The first Release run after #305 failed immediately ([run 33071607931](https://github.com/spaceribs/spaceribs/actions/runs/33071607931/job/98515014166)):

```
The --yes and --skip-publish options are mutually exclusive, please use one or the other.
```

The version step passed both. Nx 23 rejects the pair during argument parsing, so the job exited 1 before doing any work — nothing was versioned, tagged, or published. The failure is inert rather than half-applied, so there is no release state to clean up.

This is a bug I introduced in #305. I dry-ran `--skip-publish`, and separately exercised the `--yes` path, but never the combination the workflow actually shipped.

## The fix

Drop `--yes`. `--skip-publish` on its own is already fully non-interactive — from `nx/dist/src/command-line/release/release.js`:

```js
let shouldPublish = !!args.yes && !args.skipPublish && hasNewVersion;
const shouldPromptPublishing = !args.yes && !args.skipPublish && !args.dryRun && hasNewVersion;
```

Both resolve to `false`, so nothing publishes and nothing prompts. The only other prompt in the command, `promptForRemoteRelease`, is guarded by an `isCI()` early return, so it cannot block the job either.

`--yes` was never the right flag here: it means "yes, publish", which is exactly what this step must not do. Publishing stays in the separate `npm` step so it goes through `npm publish` and npm's OIDC flow rather than `pnpm publish`.

## Verification

- The broken form reproduces the CI error exactly: `nx release --yes --skip-publish --dry-run` → same message, exit 1.
- The fixed form runs the full pipeline — version, changelog, stage, commit, tag, push — and resolves:

| project | on npm | resolved from tag | new version |
|---|---|---|---|
| nx-web-ext | 6.0.1 | 6.0.1 | 6.1.0 |
| wang-tiles | 2.1.1 | 2.1.1 | 2.1.2 |
| typedoc | *not published* | 1.0.0 | 1.1.0 |

  The two backfill tags are on origin as annotated tags peeling to the right commits (`nx-web-ext-6.0.1` → `4e9a4e7`, `wang-tiles-2.1.1` → `6afb903`), so CI resolves the same versions this dry run did.

- It stops at "Creating GitHub Release" with a 403. That is this sandbox's credential limit, not a workflow defect; CI's `GITHUB_TOKEN` with `contents: write` covers it.
- `commitlint` passes on the commit.

## What the next Release run actually tests

Trusted publishers are now configured on npmjs.com, so this fix should let the run get all the way to publishing — but that path has still never executed successfully end to end. Worth watching on the first run:

- **`@spaceribs/typedoc` is not on the registry yet.** Its first publish is the least-proven step: a brand-new package name, published under OIDC, with provenance. The other two are updates to packages that already exist.
- **Provenance.** `NPM_CONFIG_PROVENANCE: true` makes npm validate `repository.url` against the building repo and reject a mismatch with a 422. All three were checked with `npm publish --dry-run`, but the attestation itself is only exercised for real on a live publish.
- **`checkExisting: "skip"`** means already-published versions no-op rather than failing the job. Since every project resolves to a new version above, all three should genuinely publish.

https://claude.ai/code/session_015WjzosrggiAncNFAyR9j4V

---
_Generated by [Claude Code](https://claude.ai/code/session_015WjzosrggiAncNFAyR9j4V)_