### PR TITLE
Push the release commit and tags with a deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,14 @@ jobs:
           # tag, so the full history and all tags have to be present.
           fetch-depth: 0
           ref: main
+          # Push over SSH as the release deploy key. A ruleset protects main
+          # and github-actions[bot] cannot be granted a bypass, so a push
+          # carrying the default GITHUB_TOKEN is rejected with GH013. Deploy
+          # keys can be bypass actors, and this key is in that list. Setting it
+          # here makes checkout point origin at the SSH remote and persist a
+          # core.sshCommand using this key, so the push nx release makes later
+          # in the job authenticates as the deploy key rather than the bot.
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - name: Setup toolchain
         uses: moonrepo/setup-toolchain@v0


### PR DESCRIPTION
## Summary

With #307 merged, the Release run got as far as pushing and was rejected by a ruleset on `main` ([run 33072596849](https://github.com/spaceribs/spaceribs/actions/runs/33072596849/job/98518395202)):

```
remote: error: GH013: Repository rule violations found for refs/heads/main
remote: - Cannot update this protected ref
 ! [remote rejected] main -> main (push declined due to repository rule violations)
 ! [remote rejected] nx-web-ext-6.1.0 -> nx-web-ext-6.1.0 (atomic transaction failed)
 ! [remote rejected] typedoc-1.1.0 -> typedoc-1.1.0 (atomic transaction failed)
 ! [remote rejected] wang-tiles-2.1.2 -> wang-tiles-2.1.2 (atomic transaction failed)
```

The push was atomic, so the branch and all three tags were refused together — nothing partial landed, and `main` is unchanged.

`github-actions[bot]` is not offered as a bypass actor on this repository, so no push carrying the default `GITHUB_TOKEN` can satisfy the rule regardless of how the workflow is written. The release has to push as an identity the ruleset will let through. Deploy keys can be bypass actors, so it pushes as one.

## The change

One input on the checkout step:

```yaml
ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
```

Verified against actions/checkout's source rather than assumed — it does both halves of what this needs:

- `getFetchUrl` returns `git@github.com:spaceribs/spaceribs.git` instead of the HTTPS URL when an ssh key is set, so `origin` is an SSH remote.
- The key is written to the runner and persisted as a local `core.sshCommand` (`persist-credentials` defaults to true), so git commands later in the job keep using it.

Together those mean the push `nx release` performs several steps later authenticates as the deploy key rather than the bot. No other step changes.

`GITHUB_TOKEN` stays on the version step: it creates the GitHub Releases through the API, which updates no refs and so is not subject to the ruleset.

## Required before this works

The workflow alone is not enough — all three of these are needed, and the run fails the same way without any one of them:

1. **A write-enabled deploy key.** Settings → Deploy keys → Add, with **Allow write access** ticked.
2. **A `RELEASE_DEPLOY_KEY` secret** holding the private half.
3. **"Deploy keys" added to the ruleset's bypass list.**

Generate the pair locally so the private key is never handled by anything else:

```bash
ssh-keygen -t ed25519 -N "" -f release_deploy_key -C "spaceribs release workflow"
```

Note that the bypass applies to *every* deploy key on the repository, not only this one. Worth keeping this key to this single purpose.

## State of the release path

Each run has failed one step later than the last. Current standing:

| stage | status |
|---|---|
| version resolution from tags | ✅ proven in CI (6.1.0, 2.1.2, 1.1.0) |
| changelog generation | ✅ proven in CI, all three packages |
| commit + tag | ✅ created, rejected only at push |
| **push to main** | ⛔ what this PR addresses |
| GitHub Releases | untested |
| npm publish (OIDC + provenance) | untested |
| `@spaceribs/typedoc` first publish | untested |

Everything from the push onward has still never executed.

https://claude.ai/code/session_015WjzosrggiAncNFAyR9j4V

---
_Generated by [Claude Code](https://claude.ai/code/session_015WjzosrggiAncNFAyR9j4V)_