### PR TITLE
Narrow publishing to the two public packages, and log OIDC failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,10 @@ jobs:
         run: pnpm exec nx run-many --target=npm --parallel=1
         env:
           NPM_CONFIG_PROVENANCE: true
+          # npm swallows a failed OIDC exchange and falls back to ordinary
+          # auth, so a mismatched trusted publisher surfaces only as ENEEDAUTH
+          # with no reason given. npm logs the registry's own explanation at
+          # verbose ("Failed token exchange request with body message: ..."),
+          # so keep this step verbose: an auth failure here is otherwise
+          # undiagnosable from the run log.
+          NPM_CONFIG_LOGLEVEL: verbose

--- a/packages/typedoc/project.json
+++ b/packages/typedoc/project.json
@@ -7,7 +7,9 @@
   "targets": {
     "build": {
       "executor": "@nx/js:tsc",
-      "outputs": ["{options.outputPath}"],
+      "outputs": [
+        "{options.outputPath}"
+      ],
       "options": {
         "outputPath": "dist/packages/typedoc",
         "main": "packages/typedoc/src/index.ts",
@@ -39,7 +41,9 @@
     },
     "lint": {
       "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"],
+      "outputs": [
+        "{options.outputFile}"
+      ],
       "options": {
         "lintFilePatterns": [
           "packages/typedoc/**/*.ts",
@@ -47,15 +51,6 @@
           "packages/typedoc/executors.json",
           "packages/typedoc/package.json"
         ]
-      }
-    },
-    "npm": {
-      "executor": "ngx-deploy-npm:deploy",
-      "dependsOn": ["build"],
-      "options": {
-        "access": "public",
-        "distFolderPath": "dist/packages/typedoc",
-        "checkExisting": "skip"
       }
     }
   }


### PR DESCRIPTION
## Summary

Two changes to the release path, after the first run that reached publishing ([run 33073761404](https://github.com/spaceribs/spaceribs/actions/runs/33073761404/job/98522492127)). The deploy key from #308 worked and everything up to the registry now succeeds:

- `main` advanced to `5cec428 chore(release): publish`
- all three tags pushed — `nx-web-ext-6.1.0`, `wang-tiles-2.1.2`, `typedoc-1.1.0`
- GitHub Releases created

Then all three packages failed with `ENEEDAUTH`.

## 1. Stop publishing `@spaceribs/typedoc`

It's used privately and has never been on the registry, so its `npm` target is removed. `nx run-many --target=npm` now resolves to `["nx-web-ext","wang-tiles"]`.

This also removes the one blocker that had no workaround in the release job: a trusted publisher can only be attached to a package that already exists, so typedoc's first publish could never have used OIDC and would have failed the step every time ([npm/cli#8544](https://github.com/npm/cli/issues/8544)). Publishing it would have needed a manual token publish first.

It stays in `nx.json`'s release config, so it keeps being versioned, changelogged and tagged — only publishing stops. That keeps its version line unbroken if it's turned back on later. Say the word if you'd rather drop it from releases entirely.

## 2. Make the remaining auth failure diagnosable

`nx-web-ext` and `wang-tiles` do exist on npm, so their `ENEEDAUTH` is a different problem — and the log can't currently say what it is.

npm was **11.19.1**, past the 11.5.1 gate, and `id-token: write` is granted, so the CLI supports trusted publishing and `ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN` are present. The exchange was attempted and rejected. npm catches that and gives up quietly, from `lib/utils/oidc.js`:

```js
} catch (error) {
  log.verbose('oidc', `Failed token exchange request with body message:
  ${error?.body?.message || 'Unknown error'}`)
  return undefined
}
```

Returning `undefined` falls through to ordinary auth, which isn't configured — so *a rejected trusted-publisher match* and *no credentials at all* look identical. The registry's own explanation is logged only at `verbose`, which the default `notice` level hides. So the publish step now sets:

```yaml
NPM_CONFIG_LOGLEVEL: verbose
```

ngx-deploy-npm runs `spawn('npm', ['publish', distFolderPath, ...])` with no `options` argument, so the child inherits `process.env` and the setting reaches npm — verified locally that a spawned npm resolves `loglevel` to `verbose` from this variable.

Kept rather than used once and reverted: this step authenticates through a mechanism that fails silently by design, and a release log that can't explain an auth failure is a liability.

## Still to determine

This makes the next failure legible; it doesn't fix it. Already ruled out — `repository.url` is correct and identical across the packages, and the executor runs a plain `npm publish <dir> --access public` with no registry override.

npm doesn't validate a trusted publisher when you save it, so a mismatch surfaces only at publish time. Worth re-checking on npmjs.com for the two remaining packages; all fields are case-sensitive:

- **Workflow filename** exactly `release.yml` — filename only, not a path
- **Organization/user** `spaceribs`, **repository** `spaceribs`
- **Allowed actions** including `npm publish`
- **Environment** left empty, since the job declares no `environment:`

## Re-running is safe

The repository is ahead of the registry: 6.1.0 and 2.1.2 are committed and tagged but unpublished. That recovers without touching versions — with the tags present, every project resolves *"No changes were detected using git history and the conventional commits standard"*, so `newVersion` is null, `createGitTagValues` produces nothing, and no duplicate tag is attempted. The publish step then retries the versions already in each `package.json`.

https://claude.ai/code/session_015WjzosrggiAncNFAyR9j4V