### PR TITLE
Publish with the pinned npm, and gate on the one nx actually spawns

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,20 +35,6 @@ jobs:
         with:
           auto-install: true
 
-      # Trusted publishing needs npm >= 11.5.1 and node 22 bundles 10.x, so the
-      # npm version is pinned in .prototools. Fail here with a clear message
-      # rather than deep inside the publish if that ever stops taking effect.
-      - name: Verify npm supports trusted publishing
-        shell: bash
-        run: |
-          required=11.5.1
-          current="$(npm --version)"
-          echo "npm $current"
-          if [ "$(printf '%s\n%s\n' "$required" "$current" | sort -V | head -1)" != "$required" ]; then
-            echo "::error::npm >= $required is required for trusted publishing, found $current"
-            exit 1
-          fi
-
       - name: Setup Git
         run: |
           git config user.name "GitHub Bot"
@@ -73,7 +59,29 @@ jobs:
       # are skipped by the executor's checkExisting option.
       - name: Publish
         shell: bash
-        run: pnpm exec nx run-many --target=npm --parallel=1
+        run: |
+          # ngx-deploy-npm spawns a bare `npm`, and that does not resolve to
+          # the npm 11 pinned in .prototools: under `pnpm exec` the running
+          # node's own bin directory wins, giving the npm bundled with node.
+          # npm 10 has no OIDC support at all, so publishing failed with
+          # ENEEDAUTH and no diagnostics. Put proto's shims first so the
+          # pinned npm wins in the child too.
+          export PATH="$HOME/.proto/shims:$HOME/.proto/bin:$PATH"
+
+          # Gate on the npm the publish will really use, resolved exactly the
+          # way nx resolves it. The previous check ran in a plain step, where
+          # `npm` resolves differently, so it passed while the publish used a
+          # version that cannot authenticate.
+          required=11.5.1
+          resolved="$(pnpm exec bash -c 'command -v npm')"
+          current="$(pnpm exec bash -c 'npm --version')"
+          echo "publish will use $resolved ($current)"
+          if [ "$(printf '%s\n%s\n' "$required" "$current" | sort -V | head -1)" != "$required" ]; then
+            echo "::error::npm >= $required is required for trusted publishing, but nx will spawn $resolved ($current)"
+            exit 1
+          fi
+
+          pnpm exec nx run-many --target=npm --parallel=1
         env:
           NPM_CONFIG_PROVENANCE: true
           # npm swallows a failed OIDC exchange and falls back to ordinary


### PR DESCRIPTION
## Summary

The verbose logging added in #309 found the cause of `ENEEDAUTH` on its first run ([run 33075103358](https://github.com/spaceribs/spaceribs/actions/runs/33075103358/job/98527134634)), and it is not a trusted publisher mismatch. The first two lines of the publish:

```
npm verbose cli /home/runner/.proto/tools/node/22.23.2/bin/node /home/runner/.proto/tools/node/22.23.2/bin/npm
npm info using npm@10.9.8
```

**npm 10.9.8.** npm 10 has no OIDC support at all, so no token exchange was ever attempted — which is why the log carried no `oidc` lines whatsoever, only the fallback to ordinary auth. The trusted publishers were never asked for anything.

This also corrects the analysis in #309: that PR asserted the exchange was attempted and rejected. It wasn't.

## Why the gate missed it

The gate reported `npm 11.19.1` and passed. Both readings are accurate — they are different binaries:

| context | resolves `npm` to | version |
|---|---|---|
| plain `run:` step (the gate) | proto's shims | 11.19.1 |
| under `pnpm exec`, spawned by nx (the publish) | the running node's own bin dir | 10.9.8 |

`.prototools` pins `npm = "11"`, and in an ordinary step proto's shims win. But ngx-deploy-npm spawns a bare `npm` from inside `pnpm exec`, where the node install's bin directory precedes the shims and yields the npm bundled with node 22.

So the check and the thing it guarded resolved different binaries. That is worse than having no check: it passed confidently while the publish used a version that cannot authenticate, and it is what sent the previous round of diagnosis after the npmjs.com configuration instead.

## The change

- **Proto's shims go first on `PATH`** for the publish step, so the pinned npm 11 wins in the spawned child too.
- **The gate moves into that step**, resolving npm exactly the way nx does, and printing what it found before running:

  ```bash
  resolved="$(pnpm exec bash -c 'command -v npm')"
  current="$(pnpm exec bash -c 'npm --version')"
  echo "publish will use $resolved ($current)"
  ```

- **The standalone gate is removed** rather than left in place, since it was measuring the wrong thing.

Verified the gate now rejects `10.9.8`, along with the boundaries either side of the threshold: 10.9.7, 10.9.8, 11.0.0 and 11.5.0 rejected; 11.5.1, 11.5.2, 11.6.0, 11.19.1 and 12.0.0 accepted.

If the `PATH` change somehow doesn't take, the run now fails loudly naming the binary it found, instead of silently attempting an unauthenticated publish. Either way the next run is conclusive.

## State of the release path

| stage | status |
|---|---|
| version resolution from tags | ✅ proven in CI |
| changelog generation | ✅ proven in CI |
| commit, tag, push to main | ✅ proven in CI (deploy key, #308) |
| GitHub Releases | ✅ proven in CI |
| npm publish (OIDC + provenance) | ⛔ what this PR addresses |

`@spaceribs/nx-web-ext@6.1.0` and `@spaceribs/wang-tiles@2.1.2` are committed and tagged but unpublished, so re-running picks them up without touching versions — every project resolves *"No changes were detected"*, `newVersion` is null, and no duplicate tag is attempted.

https://claude.ai/code/session_015WjzosrggiAncNFAyR9j4V

---
_Generated by [Claude Code](https://claude.ai/code/session_015WjzosrggiAncNFAyR9j4V)_