### PR TITLE
Install npm 11 for the publish instead of prepending proto shims

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,24 +60,38 @@ jobs:
       - name: Publish
         shell: bash
         run: |
-          # ngx-deploy-npm spawns a bare `npm`, and that does not resolve to
-          # the npm 11 pinned in .prototools: under `pnpm exec` the running
-          # node's own bin directory wins, giving the npm bundled with node.
-          # npm 10 has no OIDC support at all, so publishing failed with
-          # ENEEDAUTH and no diagnostics. Put proto's shims first so the
-          # pinned npm wins in the child too.
-          export PATH="$HOME/.proto/shims:$HOME/.proto/bin:$PATH"
-
-          # Gate on the npm the publish will really use, resolved exactly the
-          # way nx resolves it. The previous check ran in a plain step, where
-          # `npm` resolves differently, so it passed while the publish used a
-          # version that cannot authenticate.
+          # ngx-deploy-npm spawns a bare `npm`, which resolves to the npm
+          # bundled with node (10.x), not the npm 11 pinned in .prototools.
+          # npm 10 has no OIDC support at all, so the publish failed with
+          # ENEEDAUTH and no diagnostics while a gate in a plain step reported
+          # 11.x -- the two were reading different binaries.
+          #
+          # Install npm 11 into its own prefix and put that first. Upgrading
+          # the resolved npm in place is not an option: npm removes its own
+          # dependencies partway through replacing itself and dies with
+          # MODULE_NOT_FOUND. A separate prefix is an ordinary install.
           required=11.5.1
-          resolved="$(pnpm exec bash -c 'command -v npm')"
-          current="$(pnpm exec bash -c 'npm --version')"
-          echo "publish will use $resolved ($current)"
-          if [ "$(printf '%s\n%s\n' "$required" "$current" | sort -V | head -1)" != "$required" ]; then
-            echo "::error::npm >= $required is required for trusted publishing, but nx will spawn $resolved ($current)"
+          resolve() { pnpm exec bash -c 'command -v npm'; }
+          version() { pnpm exec bash -c 'npm --version'; }
+
+          npm_path="$(resolve)"
+          npm_version="$(version)"
+          echo "publish will use $npm_path ($npm_version)"
+
+          if [ "$(printf '%s\n%s\n' "$required" "$npm_version" | sort -V | head -1)" != "$required" ]; then
+            echo "npm $npm_version predates OIDC trusted publishing; installing npm 11"
+            npm install -g --prefix "$RUNNER_TEMP/npm11" npm@11
+            export PATH="$RUNNER_TEMP/npm11/bin:$PATH"
+            npm_path="$(resolve)"
+            npm_version="$(version)"
+            echo "publish will now use $npm_path ($npm_version)"
+          fi
+
+          # Resolved the same way nx resolves it, so this measures the binary
+          # that actually publishes rather than whatever the step's own PATH
+          # happens to offer.
+          if [ "$(printf '%s\n%s\n' "$required" "$npm_version" | sort -V | head -1)" != "$required" ]; then
+            echo "::error::npm >= $required is required for trusted publishing, but nx will spawn $npm_path ($npm_version)"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

The gate added in #310 worked — it stopped the run instead of letting it fail as an auth error ([run 33076290687](https://github.com/spaceribs/spaceribs/actions/runs/33076290687/job/98531229745)):

```
publish will use /home/runner/.proto/tools/node/22.23.2/bin/npm (10.9.8)
##[error]npm >= 11.5.1 is required for trusted publishing, but nx will spawn /home/runner/.proto/tools/node/22.23.2/bin/npm (10.9.8)
```

The fix in that PR did not. The `PATH` prepend was ineffective, **and the reasoning behind it was wrong**: #310 claimed `pnpm exec` re-prepends the running node's own bin directory ahead of anything the step exports. That is not what happens — a directory prepended before `pnpm exec` survives into the pnpm shell. The prepend was simply a no-op, because `$HOME/.proto/shims` and `$HOME/.proto/bin` do not provide an `npm` at all.

## The change

Install npm 11 into its own prefix and put that first:

```bash
npm install -g --prefix "$RUNNER_TEMP/npm11" npm@11
export PATH="$RUNNER_TEMP/npm11/bin:$PATH"
```

Only when the resolved npm is too old, so it is a no-op once the toolchain ships something new enough.

**Upgrading the resolved npm in place was tried first and rejected.** `npm install -g npm@11` executed by the npm being replaced removes its own dependencies partway through and dies:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

Installing into a separate prefix is an ordinary install with no self-replacement.

## Verified, not reasoned about

Each step run locally rather than assumed, since the last two attempts were both confidently wrong:

| claim | result |
|---|---|
| a dir prepended before `pnpm exec` survives into the pnpm shell | ✅ it does — which is what disproves #310's explanation |
| npm 10 can upgrade itself in place | ❌ `MODULE_NOT_FOUND` |
| npm 10 can install npm 11 into a separate prefix | ✅ 11.19.1 |
| with that prefix first, `pnpm exec` resolves to it | ✅ |
| a child spawned the way ngx-deploy-npm spawns npm sees it | ✅ reports 11.19.1 |

The gate stays, still resolving npm with `pnpm exec bash -c 'command -v npm'` so it measures the binary that actually publishes rather than whatever the step's own `PATH` offers. Boundaries re-checked: 10.9.7, 10.9.8 and 11.5.0 trigger the install; 11.5.1 and 11.19.1 pass through.

## State of the release path

| stage | status |
|---|---|
| version, changelog, commit, tag, push, GitHub Releases | ✅ proven in CI |
| npm resolves to a version that supports OIDC | ⛔ what this PR addresses |
| the OIDC exchange itself | never yet attempted |

Worth being explicit: no token exchange has ever run, so whether the trusted publishers are configured correctly is still unknown. This PR gets far enough to find out. `@spaceribs/nx-web-ext@6.1.0` and `@spaceribs/wang-tiles@2.1.2` remain committed and tagged but unpublished, and re-running picks them up without touching versions.

https://claude.ai/code/session_015WjzosrggiAncNFAyR9j4V

---
_Generated by [Claude Code](https://claude.ai/code/session_015WjzosrggiAncNFAyR9j4V)_